### PR TITLE
Move missing page handler to Hook trait

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -279,7 +279,7 @@ impl<'a> CpuRun<'a> {
         Self { cpu }
     }
 
-    pub unsafe fn run(self) -> RunState {
+    pub unsafe fn run(&self) -> RunState {
         set_hook_event(self.cpu.handle, None);
 
         self.cpu.set_run_state(RunState::Go);

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -266,6 +266,10 @@ pub trait Hooks {
     fn wrmsr(&mut self, _id: u32, _msr: u32, _val: u64) {}
 
     fn vmexit(&mut self, _id: u32, _reason: u32, _qualification: u64) {}
+
+    fn missing_page(&mut self, _paddr: PhyAddress) {
+        panic!("no missing_page function set");
+    }
 }
 
 static HOOKS: SyncUnsafeCell<Vec<&mut dyn Hooks>> = SyncUnsafeCell::new(Vec::new());
@@ -674,3 +678,16 @@ unsafe extern "C" fn bx_instr_vmexit(cpu: u32, reason: u32, qualification: u64) 
         }
     }
 }
+
+pub (crate) fn fault(gpa: PhyAddress) {
+    let hooks = unsafe { hooks() };
+    if hooks.is_empty() {
+        panic!("no fault handler set");
+    }
+
+    hooks
+        .iter_mut()
+        .for_each(|x| x.missing_page( gpa));
+
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(unwind_attributes)]
 
 #[macro_use]
 extern crate ctor;

--- a/src/mem/fastmap64_mem.rs
+++ b/src/mem/fastmap64_mem.rs
@@ -13,7 +13,7 @@ pub type FastMap64<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
 pub static MEM: SyncUnsafeCell<FastMap64<PhyAddress, *mut u8>> =
     SyncUnsafeCell::new(FastMap64::default());
 
-unsafe fn mem() -> &'static mut FastMap64<PhyAddress, *mut u8> {
+pub unsafe fn mem() -> &'static mut FastMap64<PhyAddress, *mut u8> {
     &mut (*(MEM.0.get()))
 }
 

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -1,8 +1,8 @@
 use std::slice;
 
 use crate::cpu::{cpu_bail, cpu_killbit};
-use crate::syncunsafecell::SyncUnsafeCell;
 use crate::PhyAddress;
+use crate::hook;
 
 mod phy;
 pub use phy::*;
@@ -14,24 +14,15 @@ pub use virt::*;
 // benchmarks fnvhash + hashbrown seems to be the winning combo
 mod fastmap64_mem;
 use fastmap64_mem::page_insert as mem_insert;
-pub use fastmap64_mem::page_remove;
+pub use fastmap64_mem::{mem, page_remove};
 use fastmap64_mem::{resolve_hva, resolve_hva_checked};
 
 pub const fn phy_mask(gpa: PhyAddress) -> PhyAddress {
     gpa & 0x000f_ffff_ffff_ffff
 }
 
-#[ctor]
-static FAULT: SyncUnsafeCell<Box<dyn FnMut(PhyAddress)>> =
-    SyncUnsafeCell::new(Box::new(|_| panic!("no missing_page function set")));
-
 const fn page_off(a: PhyAddress) -> (PhyAddress, usize) {
     (a & !0xfff, a as usize & 0xfff)
-}
-
-pub unsafe fn fault(gpa: PhyAddress) {
-    let f = FAULT.0.get();
-    (**f)(gpa);
 }
 
 pub unsafe fn page_insert(gpa: PhyAddress, hva: *mut u8) {
@@ -88,7 +79,7 @@ pub unsafe fn guest_phy_translate(cpu: u32, gpa: PhyAddress) -> *mut u8 {
         return hva;
     }
 
-    fault(real_gpa);
+    hook::fault(real_gpa);
 
     // check to see if our fault handler requested the cpu be killed
     if cpu_killbit(cpu) != 0 {
@@ -110,11 +101,7 @@ pub unsafe fn phy_translate(gpa: PhyAddress) -> *mut u8 {
         return hva;
     }
 
-    fault(real_gpa);
+    hook::fault(real_gpa);
 
     resolve_hva(real_gpa)
-}
-
-pub unsafe fn missing_page<T: FnMut(PhyAddress) + 'static>(f: T) {
-    *(FAULT.0.get()) = Box::new(f);
 }


### PR DESCRIPTION
Several changes I use:

- Move page fault handler to hook trait. No need to have 'static lifetime for missing page handler.
- Change cpu run from self to &self. Easier to use in loop.
- Remove unwind_attributes feature to use stable rust