### PR TITLE
Add a mode where TLBs aren't flushed

### DIFF
--- a/cabi/cpu-cabi.cc
+++ b/cabi/cpu-cabi.cc
@@ -64,6 +64,21 @@ BOCHSAPI void cpu_set_mode(unsigned id) {
 #endif
 }
 
+BOCHSAPI void cpu_set_mode_no_tlb_flush(unsigned id) {
+    BX_CPU_C *c = BX_CPU(id);
+
+#if BX_CPU_LEVEL >= 4
+    c->handleAlignmentCheck(/* CR0.AC reloaded */);
+#endif
+
+    c->handleCpuModeChange();
+
+#if BX_CPU_LEVEL >= 6
+    c->handleSseModeChange();
+#endif
+}
+
+
 // general purpose regs
 
 BOCHSAPI bx_address cpu_get_pc(unsigned id) {


### PR DESCRIPTION
The goal of this PR is to expose logic to allow callers to not flush TLBs - I've noticed 10x improvement on specific workflow (rp-bf) where page tables can't change.