### PR TITLE
`c_unwind` has been stabilized in 1.71.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "bochscpu"
 version = "0.1.0"
 authors = ["x"]
 edition = "2021"
+rust-version = "1.71.0"
 
 [lib]
 crate-type = ["dylib", "rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(c_unwind)]
-
 #[macro_use]
 extern crate ctor;
 #[macro_use]


### PR DESCRIPTION
cf https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html