### PR TITLE
Minor fixups to build BochsCPU for Bochs v2.8 

### DIFF
--- a/cabi/cpu-cabi.cc
+++ b/cabi/cpu-cabi.cc
@@ -3,6 +3,7 @@
 
 #include "bochs.h"
 #include "cpu/cpu.h"
+#include "cpu/apic.h"
 #include "pc_system.h"
 
 typedef BX_CPU_C *BX_CPU_C_PTR;
@@ -284,7 +285,7 @@ BOCHSAPI Bit32u cpu_get_cr8(unsigned id) {
 }
 
 BOCHSAPI void cpu_set_cr8(unsigned id, Bit32u v) {
-    BX_CPU(id)->lapic.set_tpr((v & 0xf) << 4);
+    BX_CPU(id)->lapic->set_tpr((v & 0xf) << 4);
 }
 
 BOCHSAPI Bit32u cpu_get_efer(unsigned id) {

--- a/cabi/mem-cabi.cc
+++ b/cabi/mem-cabi.cc
@@ -10,11 +10,13 @@ extern "C" {
 }
 }
 
-BX_MEM_C::BX_MEM_C() {}
-BX_MEM_C::~BX_MEM_C() {}
+BX_MEM_C::BX_MEM_C() = default;
+BX_MEM_C::~BX_MEM_C() = default;
+BX_MEMORY_STUB_C::BX_MEMORY_STUB_C() = default;
+BX_MEMORY_STUB_C::~BX_MEMORY_STUB_C() = default;
 
 void BX_MEM_C::writePhysicalPage(BX_CPU_C *cpu, bx_phy_address addr,
-    unsigned len, void *data)
+                                                                      unsigned len, void *data)
 {
     return rust::mem_write_phy(cpu->which_cpu(), addr, len, data);
 }
@@ -34,6 +36,11 @@ bool BX_MEM_C::dbg_fetch_mem(BX_CPU_C *cpu, bx_phy_address addr, unsigned len, B
     assert(false);
 
     return false;
+}
+
+Bit64u BX_MEMORY_STUB_C::get_memory_len()
+{
+    return (BX_MEM_THIS len);
 }
 
 BOCHSAPI BX_MEM_C bx_mem;

--- a/cabi/paramtree.cc
+++ b/cabi/paramtree.cc
@@ -47,8 +47,8 @@ bx_param_c::bx_param_c(Bit32u id, const char *param_name, const char *param_desc
   this->name = new char[strlen(param_name)+1];
   strcpy(this->name, param_name);
   set_description(param_desc);
-  this->text_format = default_text_format;
-  this->long_text_format = default_text_format;
+  this->text_format = (char*)default_text_format;
+  this->long_text_format = (char*)default_text_format;
   this->runtime_param = 0;
   this->enabled = 1;
   this->options = 0;
@@ -70,8 +70,8 @@ bx_param_c::bx_param_c(Bit32u id, const char *param_name, const char *param_labe
   strcpy(this->name, param_name);
   set_description(param_desc);
   set_label(param_label);
-  this->text_format = default_text_format;
-  this->long_text_format = default_text_format;
+  this->text_format = (char*)default_text_format;
+  this->long_text_format = (char*)default_text_format;
   this->runtime_param = 0;
   this->enabled = 1;
   this->options = 0;
@@ -371,7 +371,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p64bit = ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x" FMT_LL "x";
+    this->text_format = (char*)"0x" FMT_LL "x";
   }
 }
 
@@ -390,7 +390,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p64bit = (Bit64s*) ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x" FMT_LL "x";
+    this->text_format = (char*)"0x" FMT_LL "x";
   }
 }
 
@@ -409,7 +409,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p32bit = ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x%08x";
+    this->text_format = (char*)"0x%08x";
   }
 }
 
@@ -428,7 +428,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p32bit = (Bit32s*) ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x%08x";
+    this->text_format = (char*)"0x%08x";
   }
 }
 
@@ -447,7 +447,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p16bit = ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x%04x";
+    this->text_format = (char*)"0x%04x";
   }
 }
 
@@ -466,7 +466,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p16bit = (Bit16s*) ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x%04x";
+    this->text_format = (char*)"0x%04x";
   }
 }
 
@@ -486,7 +486,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p8bit = ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x%02x";
+    this->text_format = (char*)"0x%02x";
   }
 }
 
@@ -505,7 +505,7 @@ bx_shadow_num_c::bx_shadow_num_c(bx_param_c *parent,
   val.p8bit = (Bit8s*) ptr_to_real_val;
   if (base == BASE_HEX) {
     this->base = base;
-    this->text_format = "0x%02x";
+    this->text_format = (char*)"0x%02x";
   }
 }
 


### PR DESCRIPTION
Everything the title says 😄 
Basically it was mostly only due to the introduction of memory stubs in bochs (see https://github.com/bochs-emu/Bochs/commit/32cab8f384656d88be2d69e3125957455bfaff6f)

The changes are pretty minor and with those small changes, everything seems to [build and test in bochscpu-python](https://github.com/hugsy/bochscpu-python/actions/runs/8302121981)

Cheers 