### PR TITLE
add macos support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           # - windows-11-arm  #   C:\code\bochscpu\bochs\config.h(94): fatal error C1189: #error:  Bochs not configured for MSVC WIN32
           - ubuntu-24.04
           - ubuntu-24.04-arm
+          - macos-latest
         build: [debug, release]
 
     name: ${{ matrix.os }}/${{ matrix.build }}

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,8 @@ fn get_bochscpu_build_url(version: Option<&str>) -> (String, String) {
     let filename: &str = "bochscpu-build-ubuntu-latest-x64.zip";
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     let filename: &str = "bochscpu-build-ubuntu-24.04-arm-arm64.zip";
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    let filename: &str = "bochscpu-build-macos-latest-arm64.zip";
 
     let asset = js["assets"]
         .members()
@@ -57,7 +59,7 @@ fn download_bochscpu_build(url: &str) {
         "Release"
     };
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     let tempfile = std::path::PathBuf::from(format!(
         "{}/bochscpu-build-{}.zip",
         std::env::var("TEMP").unwrap_or("/tmp".to_string()),


### PR DESCRIPTION
This is to add macos support to the crate. This depends on https://github.com/yrp604/bochscpu-build/pull/23 being merged first, so that macos releases become available for download.

Tested locally by stubbing the return value of `get_bochscpu_build_url` with a local build of `bochscpu-build` and running `bochscpu-bench`.